### PR TITLE
Improve reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,13 @@
   "author": "Christopher Knötschke <cknoetschke@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "gulp-util": "^2.2.14",
+    "app-root-path": "^1.0.0",
+    "colors": "^1.0.3",
     "event-stream": "^3.1.1",
-    "lintspaces": "^0.3.2"
+    "gulp-util": "^2.2.14",
+    "lintspaces": "^0.3.2",
+    "log-symbols": "^1.0.2",
+    "path": "^0.11.14"
   },
   "devDependencies": {
     "should": "^3.2.0",


### PR DESCRIPTION
This improves the reporter so that the stream isn't broken on the first linter warning (it lints all files in the stream before throwing an error). It also adds `breakOnWarning` and `prefixLogs` options (both default to `false`) which allow control over whether linting warnings should throw an error, and whether log lines should be prefixed with `[gulp-lintspaces]`. Along with these changes, the formatting is also improved. Here are some screenshots;
![screen shot 2016-01-28 at 2 40 23 pm](https://cloud.githubusercontent.com/assets/516388/12653195/7f446e14-c5d5-11e5-8ca2-7157b387b650.png)
![screen shot 2016-01-28 at 2 41 55 pm](https://cloud.githubusercontent.com/assets/516388/12653234/b725065e-c5d5-11e5-8f31-40a31098dfbb.png)
