### PR TITLE
Update lintspace dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "colors": "^1.0.3",
     "event-stream": "^3.1.1",
     "gulp-util": "^2.2.14",
-    "lintspaces": "^0.3.2",
+    "lintspaces": "^0.5.0",
     "log-symbols": "^1.0.2",
     "path": "^0.11.14"
   },


### PR DESCRIPTION
Semver carets work different for 0.x versions and it is not picking up the latest

cc/ @sidewalksalsa, @hershmire
